### PR TITLE
Add meters for aggregating averages and moments

### DIFF
--- a/uv/meters/__init__.py
+++ b/uv/meters/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/uv/meters/avg_meter.py
+++ b/uv/meters/avg_meter.py
@@ -1,0 +1,16 @@
+class AverageMeter:
+
+  def __init__(self):
+    self.reset()
+
+  def reset(self):
+    self.val = 0
+    self.avg = 0
+    self.sum = 0
+    self.count = 0
+
+  def update(self, val, num):
+    self.val = val
+    self.sum += val * num
+    self.count += num
+    self.avg = self.sum / self.count

--- a/uv/meters/moment_meter.py
+++ b/uv/meters/moment_meter.py
@@ -1,0 +1,48 @@
+import numpy as np
+import torch
+
+
+class TorchMomentAggregator:
+
+  def __init__(self, max_moment=2):
+    self.max_moment = max_moment
+    self.shape = None
+
+  def initialize(self, shape):
+    self.shape = shape
+    self.moments = [torch.zeros(shape) for m in range(self.max_moment)]
+    self.count = 0
+
+  def reset(self):
+    self.initialize(shape)
+
+  def update(self, sample_measurements):
+    # Zeroth dimension is sample dimension
+    if self.shape is None:
+      self.initialize(sample_measurements.shape[1:])
+
+    for moment in range(self.max_moment):
+      self.update_moment(moment, sample_measurements)
+    self.update_count(sample_measurements)
+
+  def update_moment(self, moment, sample_measurements):
+    with torch.no_grad():
+      batch_size = len(sample_measurements)
+      batch_avgd_moment = torch.mean(torch.pow(sample_measurements, moment + 1),
+                                     axis=0)
+      full_count = self.count + batch_size
+      full_stat = self.count * self.moments[
+          moment] + batch_size * batch_avgd_moment
+      self.moments[moment] = full_stat / full_count
+
+  def update_count(self, sample_measurements):
+    self.count += len(sample_measurements)
+
+  def get_cumulants(self):
+    if self.max_moment > 2:
+      raise NotImplementedError(
+          'MomentAggregator can only convert moments to cumulants for n<=2')
+    elif self.max_moment == 1:
+      return self.moments
+    elif self.max_moment == 2:
+      return [self.moments[0], self.moments[1] - torch.pow(self.moments[0], 2)]


### PR DESCRIPTION
This PR adds two meters for tracking quantities, an AverageMeter and a MomentMeter.  Both files live in the `meters` folder.  

TODOs:
- Currently imports torch, should fix that
- Currently does not have type annotations