### PR TITLE
MLFlowReporter, params, environment params

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,5 @@ pre-commit
 pytest==5.4.3
 pytest-cov==2.10.0
 tensorflow # for testing tensorboard.
+mlflow
 twine

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 def with_versioneer(f, default=None):
@@ -38,8 +38,13 @@ def readme():
 
 CASFS_VERSION = "0.1.0"
 REQUIRED_PACKAGES = [
-    "numpy>=1.18.0", "tqdm>=4.42.1", "fs", "fs-gcsfs", "casfs==0.1.1",
-    "sqlalchemy"
+    "casfs==0.1.1",
+    "fs",
+    "fs-gcsfs",
+    "mlflow==1.10.0",
+    "numpy>=1.18.0",
+    "sqlalchemy",
+    "tqdm>=4.42.1",
 ]
 
 setup(
@@ -59,7 +64,6 @@ setup(
     extras_require={
         "tf": ["tensorflow"],
         "tf-gpu": ["tensorflow-gpu"],
-        "mlflow": ["mlflow"],
     },
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     extras_require={
         "tf": ["tensorflow"],
         "tf-gpu": ["tensorflow-gpu"],
+        "mlflow": ["mlflow"],
     },
     include_package_data=True,
 )

--- a/tests/uv/reporter/test_state.py
+++ b/tests/uv/reporter/test_state.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uv.reporter.state as s
+import uv.reporter.store as r
+
+
+def test_global_reporter():
+  r1 = r.MemoryReporter()
+  reader1 = r1.reader()
+
+  r2 = r.MemoryReporter()
+  reader2 = r2.reader()
+
+  r3 = r.MemoryReporter()
+  reader3 = r3.reader()
+
+  # By default, we get the null reporter and nothing happens.
+  assert s.report(1, "face", 2) is None
+  assert s.report_all(2, {"face": 2, "cake": 3}) is None
+
+  s.set_reporter(r1)
+
+  # boom!
+  assert s.get_reporter() == r1
+
+  # Now, reports go into the global reporter.
+  s.report(1, "face", 2)
+  s.report_all(2, {"face": 2, "cake": 3})
+
+  # confirm:
+  assert reader1.read("face") == [2, 2]
+  assert reader1.read_all(["face", "cake"]) == {"face": [2, 2], "cake": [3]}
+
+  with s.active_reporter(r2):
+    # These report go through to r2, not r1.
+    s.report(1, "hammer", 2)
+    s.report_all(1, {"steve": 2, "john": 3})
+
+    assert reader1.read_all(["hammer", "steve", "john"]) == {
+        "hammer": [],
+        "john": [],
+        "steve": []
+    }
+
+    assert reader2.read_all(["hammer", "steve", "john"]) == {
+        "hammer": [2],
+        "john": [3],
+        "steve": [2]
+    }
+
+    # these can nest:
+    with s.active_reporter(r3):
+      s.report(4, "deeper", 10)
+
+      assert reader2.read("deeper") == []
+      assert reader3.read("deeper") == [10]
+
+    # when you leave a block, you hit the next reporter back.
+    s.report(4, "deeper", 12)
+    assert reader2.read("deeper") == [12]
+    assert reader3.read("deeper") == [10]

--- a/tests/uv/reporter/test_state.py
+++ b/tests/uv/reporter/test_state.py
@@ -45,7 +45,18 @@ def test_global_reporter():
   assert reader1.read("face") == [2, 2]
   assert reader1.read_all(["face", "cake"]) == {"face": [2, 2], "cake": [3]}
 
+  # params are correctly reported.
+  s.report_param("key_for_me", "value")
+  s.report_params({"k": "v", "k2": "v2"})
+  assert r1._params == {"key_for_me": "value", "k": "v", "k2": "v2"}
+
   with s.active_reporter(r2):
+
+    # params get reported to the proper reporter.
+    s.report_param("key", "value")
+    assert r1._params == {"key_for_me": "value", "k": "v", "k2": "v2"}
+    assert r2._params == {"key": "value"}
+
     # These report go through to r2, not r1.
     s.report(1, "hammer", 2)
     s.report_all(1, {"steve": 2, "john": 3})

--- a/tests/uv/sql/test_sql.py
+++ b/tests/uv/sql/test_sql.py
@@ -57,7 +57,7 @@ def test_rep_string():
   assert "params='None'" in str(metric)
 
 
-def test_sql_roundtrip(tmp_path):
+def test_of_sql_roundtrip(tmp_path):
   engine = u.sqlite_engine(str(tmp_path))
 
   # you can't make a reporter with an engine pointing to a nonexistent DB:

--- a/tests/uv/sql/test_sql.py
+++ b/tests/uv/sql/test_sql.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """Tests for the SQL reader and reporter."""
 
+import time
 from contextlib import closing
 
 import uv.sql.reporter as sr
@@ -75,6 +76,7 @@ def test_of_sql_roundtrip(tmp_path):
     with closing(reporter.reader()) as reader:
       with closing(sr.SQLReader(engine, experiment, 0)) as reader2:
 
+        time.sleep(0.4)
         reporter.report_all(0, {"a": 1})
         reporter.report_all(1, {"a": 2, "b": 3})
         reporter.report_all(2, {"b": 4})

--- a/tests/uv/sql/test_sql.py
+++ b/tests/uv/sql/test_sql.py
@@ -76,7 +76,7 @@ def test_of_sql_roundtrip(tmp_path):
     with closing(reporter.reader()) as reader:
       with closing(sr.SQLReader(engine, experiment, 0)) as reader2:
 
-        time.sleep(0.4)
+        time.sleep(1)
         reporter.report_all(0, {"a": 1})
         reporter.report_all(1, {"a": 2, "b": 3})
         reporter.report_all(2, {"b": 4})

--- a/tests/uv/tensorflow/test_reporter.py
+++ b/tests/uv/tensorflow/test_reporter.py
@@ -72,8 +72,8 @@ logged, false otherwise."""
   return len(event.summary.value) > 0
 
 
-def get_summaries(events: Iterable[event_pb2.Event]
-                 ) -> Iterable[Dict[str, Any]]:
+def get_summaries(
+    events: Iterable[event_pb2.Event]) -> Iterable[Dict[str, Any]]:
   """Returns a sequence of dictionaries represen"""
 
   def process(e):

--- a/tests/uv/util/test_env.py
+++ b/tests/uv/util/test_env.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import uv.util.env as ue
+
+
+def test_extract_params(monkeypatch):
+
+  def mem_env(prefix):
+    return {
+        f"{prefix}_MY_KEY": "face",
+        f"{prefix}_ANOTHER_KEY": "sandwich",
+        f"{prefix}THIRD_KEY": "ham"
+    }
+
+  expected = {"my_key": "face", "another_key": "sandwich", "third_key": "ham"}
+
+  # with various prefixes, a custom-supplied environment will return the
+  # correctly parsed env variables.
+  assert expected == ue.extract_params(prefix="ENVVAR", env=mem_env("ENVVAR"))
+  assert expected == ue.extract_params(prefix="funky", env=mem_env("funky"))
+
+  k = f"{ue._ENV_VAR_PREFIX}_RANDOM_KEY"
+  v = "better_not_be_set"
+
+  # make sure we don't have some random value set
+  if os.environ.get(k):
+    monkeypatch.delenv(k)
+
+  # the environment should be empty.
+  assert ue.extract_params() == {}
+
+  # set our expected kv pair...
+  monkeypatch.setenv(k, v)
+
+  # and get it back from the env.
+  assert ue.extract_params() == {"random_key": v}

--- a/uv/__init__.py
+++ b/uv/__init__.py
@@ -13,6 +13,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from uv.reporter.state import (active_reporter, get_reporter, report,
+                               report_all, set_reporter)
+
+from mlflow import start_run
+
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions
+
+__all__ = [
+    "active_reporter",
+    "get_reporter",
+    "set_reporter",
+    "report",
+    "report_all",
+    "start_run",
+    "AbstractReporter",
+    "LoggingReporter",
+    "MemoryReporter",
+]

--- a/uv/__init__.py
+++ b/uv/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "set_reporter",
     "report",
     "report_all",
+    "start_run",
     "AbstractReporter",
     "LoggingReporter",
     "MemoryReporter",

--- a/uv/__init__.py
+++ b/uv/__init__.py
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from uv.reporter.state import (active_reporter, get_reporter, report,
-                               report_all, set_reporter)
-
-from mlflow import start_run
+                               report_all, set_reporter, start_run)
 
 from ._version import get_versions
 
@@ -29,7 +27,6 @@ __all__ = [
     "set_reporter",
     "report",
     "report_all",
-    "start_run",
     "AbstractReporter",
     "LoggingReporter",
     "MemoryReporter",

--- a/uv/__init__.py
+++ b/uv/__init__.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 from uv.reporter.base import AbstractReporter
 from uv.reporter.state import (active_reporter, get_reporter, report,
-                               report_all, set_reporter, start_run)
+                               report_all, report_param, report_params,
+                               set_reporter, start_run)
 from uv.reporter.store import LoggingReporter, MemoryReporter
 
 from ._version import get_versions
@@ -29,6 +30,8 @@ __all__ = [
     "set_reporter",
     "report",
     "report_all",
+    "report_param",
+    "report_params",
     "start_run",
     "AbstractReporter",
     "LoggingReporter",

--- a/uv/__init__.py
+++ b/uv/__init__.py
@@ -13,8 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from uv.reporter.base import AbstractReporter
 from uv.reporter.state import (active_reporter, get_reporter, report,
                                report_all, set_reporter, start_run)
+from uv.reporter.store import LoggingReporter, MemoryReporter
 
 from ._version import get_versions
 

--- a/uv/mlflow/__init__.py
+++ b/uv/mlflow/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/uv/mlflow/reporter.py
+++ b/uv/mlflow/reporter.py
@@ -18,7 +18,6 @@
 from typing import Dict
 
 import mlflow
-
 import uv.reporter.base as b
 import uv.types as t
 
@@ -28,6 +27,12 @@ class MLFlowReporter(b.AbstractReporter):
 
   def __init__(self):
     pass
+
+  def report_param(self, k: str, v: str) -> None:
+    mlflow.log_param(k, v)
+
+  def report_params(self, m: Dict[str, str]) -> None:
+    mlflow.log_params(m)
 
   def report_all(self, step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
     mlflow.log_metrics(m, step=step)

--- a/uv/mlflow/reporter.py
+++ b/uv/mlflow/reporter.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MLFlow reporter that conforms to UV's reporter interface."""
+
+from typing import Dict
+
+import mlflow
+
+import uv.reporter.base as b
+import uv.types as t
+
+
+class MLFlowReporter(b.AbstractReporter):
+  """Reporter implementation that logs metrics to mlflow."""
+
+  def __init__(self):
+    pass
+
+  def report_all(self, step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
+    mlflow.log_metrics(m, step=step)
+
+  def report(self, step: int, k: t.MetricKey, v: t.Metric) -> None:
+    mlflow.log_metric(key=k, value=v, step=step)

--- a/uv/reporter/__init__.py
+++ b/uv/reporter/__init__.py
@@ -15,11 +15,11 @@
 # limitations under the License.
 """Reporter interface and implementations."""
 
-from mlflow import log_params, start_run
 from uv.reporter.base import AbstractReporter
 from uv.reporter.store import LoggingReporter, MemoryReporter
 
 __all__ = [
-    "AbstractReporter", "LoggingReporter", "MemoryReporter", "log_params",
-    "start_run"
+    "AbstractReporter",
+    "LoggingReporter",
+    "MemoryReporter",
 ]

--- a/uv/reporter/__init__.py
+++ b/uv/reporter/__init__.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 """Reporter interface and implementations."""
 
+from mlflow import log_params, start_run
 from uv.reporter.base import AbstractReporter
 from uv.reporter.store import LoggingReporter, MemoryReporter
 
-__all__ = ["AbstractReporter", "LoggingReporter", "MemoryReporter"]
+__all__ = ["AbstractReporter", "LoggingReporter", "MemoryReporter", "log_params". "start_run"]

--- a/uv/reporter/__init__.py
+++ b/uv/reporter/__init__.py
@@ -19,4 +19,7 @@ from mlflow import log_params, start_run
 from uv.reporter.base import AbstractReporter
 from uv.reporter.store import LoggingReporter, MemoryReporter
 
-__all__ = ["AbstractReporter", "LoggingReporter", "MemoryReporter", "log_params". "start_run"]
+__all__ = [
+    "AbstractReporter", "LoggingReporter", "MemoryReporter", "log_params",
+    "start_run"
+]

--- a/uv/reporter/base.py
+++ b/uv/reporter/base.py
@@ -228,6 +228,12 @@ class FilterValuesReporter(AbstractReporter):
     self._pred = predicate
     self._on_false_reporter = on_false_reporter
 
+  def report_param(self, k: str, v: str) -> None:
+    return self._base.report_param(k, v)
+
+  def report_params(self, m: Dict[str, str]) -> None:
+    return self._base.report_params(m)
+
   def report_all(self, step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
     good = {k: v for k, v in m.items() if self._pred(step, v)}
     bad = {k: v for k, v in m.items() if not self._pred(step, v)}
@@ -270,6 +276,12 @@ class MapValuesReporter(AbstractReporter):
                                                           t.Metric]):
     self._base = base
     self._fn = fn
+
+  def report_param(self, k: str, v: str) -> None:
+    return self._base.report_param(k, v)
+
+  def report_params(self, m: Dict[str, str]) -> None:
+    return self._base.report_params(m)
 
   def report_all(self, step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
     self._base.report_all(step, {k: self._fn(step, v) for k, v in m.items()})
@@ -324,6 +336,12 @@ class PrefixedReporter(AbstractReporter):
     self._base = base
     self._prefix = prefix
 
+  def report_param(self, k: str, v: str) -> None:
+    return self._base.report_param(k, v)
+
+  def report_params(self, m: Dict[str, str]) -> None:
+    return self._base.report_params(m)
+
   def report_all(self, step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
     self._base.report_all(step, a.attach(m, self._prefix, prefix=True))
 
@@ -351,6 +369,12 @@ class SuffixedReporter(AbstractReporter):
   def __init__(self, base: AbstractReporter, suffix: t.Suffix):
     self._base = base
     self._suffix = suffix
+
+  def report_param(self, k: str, v: str) -> None:
+    return self._base.report_param(k, v)
+
+  def report_params(self, m: Dict[str, str]) -> None:
+    return self._base.report_params(m)
 
   def report_all(self, step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
     self._base.report_all(step, a.attach(m, self._suffix, prefix=False))
@@ -383,6 +407,12 @@ class ThunkReporter(AbstractReporter):
 
   def thunk(self, step: int) -> None:
     self.report_all(step, self._thunk())
+
+  def report_param(self, k: str, v: str) -> None:
+    return self._base.report_param(k, v)
+
+  def report_params(self, m: Dict[str, str]) -> None:
+    return self._base.report_params(m)
 
   def report_all(self, step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
     self._base.report_all(step, m)

--- a/uv/reporter/base.py
+++ b/uv/reporter/base.py
@@ -38,6 +38,20 @@ class AbstractReporter(metaclass=ABCMeta):
 
   """
 
+  def report_param(self, k: str, v: str) -> None:
+    """Accepts a key and value parameter and logs these as parameters alongside the
+    reported metrics.
+
+    """
+    return None
+
+  def report_params(self, m: Dict[str, str]) -> None:
+    """Accepts a dict of parameter name -> value, and logs these as parameters
+    alongside the reported metrics.
+
+    """
+    return None
+
   def report_all(self, step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
     """Accepts a step (an ordered int referencing some timestep) and a dictionary
     of metric key => metric value, and persists the metric into some underlying

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """Reporter interface and implementations."""
 
+import os
 from contextlib import contextmanager
 from typing import Dict
 
@@ -84,13 +85,20 @@ def report_params(m: Dict[str, str]) -> None:
   return get_reporter().report_params(m)
 
 
-def start_run(param_prefix=None, **args):
+def start_run(param_prefix: str = None, experiment_name: str = None, **args):
   """Close alias of mlflow.start_run. The only difference is that uv.start_run
   attempts to extract parameters from the environment and log those to the
   bound UV reporter using `report_params`.
 
   """
+  if experiment_name is None:
+    experiment_name = os.environ.get("MLFLOW_EXPERIMENT_NAME")
+
+  # Make sure the experiment exists before the run starts.
+  if experiment_name is not None:
+    mlf.set_experiment(experiment_name)
+
   ret = mlf.start_run(**args)
   env_params = ue.extract_params(prefix=param_prefix)
-  report_params(env_params)
+  mlf.set_tags(env_params)
   return ret

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reporter interface and implementations."""
+
+from contextlib import contextmanager
+from typing import Dict
+
+import uv.types as t
+from uv.reporter.base import AbstractReporter
+from uv.reporter.store import NullReporter
+
+_active_reporter = None
+
+
+def get_reporter() -> AbstractReporter:
+  """Returns the active reporter set using set_reporter()"""
+  if _active_reporter is not None:
+    return _active_reporter
+  return NullReporter()
+
+
+def set_reporter(r: AbstractReporter) -> AbstractReporter:
+  """Set the globally available reporter instance. Returns its input."""
+  global _active_reporter
+  _active_reporter = r
+
+
+@contextmanager
+def active_reporter(r: AbstractReporter):
+  old_reporter = _active_reporter
+  globals()['_active_reporter'] = r
+  yield
+  globals()['_active_reporter'] = old_reporter
+
+
+def report(step: int, k: t.MetricKey, v: t.Metric) -> None:
+  """Accepts a step (an ordered int referencing some timestep), a metric key and
+    a value, and persists the metric into the globally available reporter
+    returned by uv.get_reporter().
+
+  """
+  return get_reporter().report(step, k, v)
+
+
+def report_all(step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
+  """Accepts a step (an ordered int referencing some timestep) and a dictionary
+    of metric key => metric value, and persists the metric into the globally
+    available reporter returned by uv.get_reporter().
+
+  """
+  return get_reporter().report_all(step, m)

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -18,7 +18,9 @@
 from contextlib import contextmanager
 from typing import Dict
 
+import mlflow as mlf
 import uv.types as t
+import uv.util.env as ue
 from uv.reporter.base import AbstractReporter
 from uv.reporter.store import NullReporter
 
@@ -62,3 +64,33 @@ def report_all(step: int, m: Dict[t.MetricKey, t.Metric]) -> None:
 
   """
   return get_reporter().report_all(step, m)
+
+
+def report_param(k: str, v: str) -> None:
+  """Accepts a key and value parameter and logs these as parameters alongside the
+    reported metrics. Reports to the globally available reporter returned by
+    uv.get_reporter().
+
+    """
+  return get_reporter().report_param(k, v)
+
+
+def report_params(m: Dict[str, str]) -> None:
+  """Accepts a dict of parameter name -> value, and logs these as parameters
+  alongside the reported metrics. Reports to the globally available reporter
+  returned by uv.get_reporter().
+
+  """
+  return get_reporter().report_params(m)
+
+
+def start_run(param_prefix=None, **args):
+  """Close alias of mlflow.start_run. The only difference is that uv.start_run
+  attempts to extract parameters from the environment and log those to the
+  bound UV reporter using `report_params`.
+
+  """
+  ret = mlf.start_run(**args)
+  env_params = ue.extract_params(prefix=param_prefix)
+  report_params(env_params)
+  return ret

--- a/uv/sql/reporter.py
+++ b/uv/sql/reporter.py
@@ -30,7 +30,6 @@ from sqlalchemy import JSON, REAL, Column, Integer, String
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.query import Query
 from uv.reporter.base import AbstractReporter
 
 Base = declarative_base()

--- a/uv/util/env.py
+++ b/uv/util/env.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for interacting with the system environment."""
+
+import os
+from typing import Dict, Optional
+
+_ENV_VAR_PREFIX = "ENVVAR"
+
+
+def extract_params(prefix: Optional[str] = None,
+                   env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+  """Some libraries that interact with UV pass experiment parameters via
+  environment variables. This function returns a dict containing all
+  environment keys (and their values) that begin with the supplied prefix and,
+  optionally, an underscore.
+
+  An environment like this:
+
+  ENVVAR_MY_KEY=face
+  ENVVAR_ANOTHER_KEY=sandwich
+  ENVVARTHIRD_KEY=ham
+
+  would return:
+
+  {
+    "my_key": "face",
+    "another_key": "sandwich",
+    "third_key": "ham"
+  }
+
+  """
+  if prefix is None:
+    prefix = _ENV_VAR_PREFIX
+
+  if env is None:
+    env = os.environ
+
+  def relevant():
+    for k, v in env.items():
+      if k.startswith(prefix):
+        stripped = k[len(prefix):].lstrip("_")
+        yield stripped.lower(), v
+
+  return dict(relevant())


### PR DESCRIPTION
This PR:

- Exposes methods to work with reporters using global state
- adds a new `MLFlowReporter`
- adds `report_param` and `report_params` methods to all reporters.
- adds an alias for mlflow's `start_run` that will scrape parameters out of the current execution environment.