### PR TITLE
[refs #00000] Add manager

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,4 +12,6 @@ Welcome.
 Indices and tables
 ==================
 
+* :ref:`genindex`
+* :ref:`modindex`
 * :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,10 +7,9 @@ Welcome.
    :maxdepth: 2
    :caption: Contents:
 
+   uv/manager
 
 Indices and tables
 ==================
 
-* :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`

--- a/docs/uv/manager.rst
+++ b/docs/uv/manager.rst
@@ -39,7 +39,7 @@ dictionary.  For example:
                                   'interval': 10,
                                   'function': lambda state: l2norm(state['params']}))
 
-Then, during training, we can call the `process` function, but we need to pass
+Then, during training, we can call the `measure` function, but we need to pass
 the objects needed for measurements which vary during traning, e.g.
 
 .. code-block:: python
@@ -48,15 +48,25 @@ the objects needed for measurements which vary during traning, e.g.
         optimizer_state = do_train_step()
 
         current_dict = {'params': optimizer_state.params}
-        oscilloscope.process(step, current_dict)
+        oscilloscope.measure(step, current_dict)
 
 If we want to perform a measurement at any time (say outside the normal
-schedule), we can use the `perform_specified_measurements` method as follows:
+schedule), we can use the same `measure` method, but now we must provide the
+argument `measurement_list` as follows:
 
 .. code-block:: python
 
-    oscilloscope.perform_specified_measurements(step, current_dict,
-                                                ['test_acc'])
+    oscilloscope.measure(step, current_dict, measurement_list=['test_acc'])
+
+This will measure, in the above case, `test_acc`, regardless of what the
+corresponding measurement interval and step are.
+
+.. warning::
+    When you call `.measure()` with an explicit `measurement_list`, the manager
+    will only measure those measurements in the list, and will NOT go through
+    and check which measurements to perform based on the measurement-intervals.
+    If you want to measure those as well, you must call `.measure()` again, with
+    no `measurement_list` provided.
 
 Indices and tables
 ==================

--- a/docs/uv/manager.rst
+++ b/docs/uv/manager.rst
@@ -13,14 +13,17 @@ measurements (e.g., the test dataset), e.g.:
 
 .. code-block:: python
 
+    import uv.manager as m
+    import uv.reporter as r
+
     # make reporter
-    reporter = reporters.build_reporters()
+    reporter = r.MemoryReporter().stepped()
 
     # make static state dictionary
     static_state = {'test_set': test_dset}
 
     # initialize manager
-    oscilloscope = manager.MeasurementManager(static_state, reporter)
+    oscilloscope = m.MeasurementManager(static_state, reporter)
 
 Once the `MeasurementManager` is initialized, you must then tell it which
 measurements to make, and at what interval to make them.  The measurement is
@@ -47,12 +50,14 @@ the objects needed for measurements which vary during traning, e.g.
         current_dict = {'params': optimizer_state.params}
         oscilloscope.process(step, current_dict)
 
-If we want to force a measurement when it wouldn't ordinarily be measured, we
-can use the `trigger_subset` method as follows
+If we want to perform a measurement at any time (say outside the normal
+schedule), we can use the `perform_specified_measurements` method as follows:
 
 .. code-block:: python
 
-    oscilloscope.trigger_subset(step, current_dict, ['test_acc']
+    oscilloscope.perform_specified_measurements(step, current_dict,
+                                                ['test_acc'])
+
 Indices and tables
 ==================
 

--- a/docs/uv/manager.rst
+++ b/docs/uv/manager.rst
@@ -1,0 +1,59 @@
+Measurement Manager
+==========
+
+While reporters in `uv-metrics` handle values that have already been measured,
+the `MeasurementManager` feature allows you to schedule certain measurements to
+run at specified intervals (which may be different for each measurement), and
+automatically report the results.
+
+A `MeasurementManager` object holds a `reporter`, which it will use to report
+the measurements it makes.  To initialize a `MeasurementManager`, one passes
+a reporter and a dictionary containing items which are necessary to make the
+measurements (e.g., the test dataset), e.g.:
+
+.. code-block:: python
+
+    # make reporter
+    reporter = reporters.build_reporters()
+
+    # make static state dictionary
+    static_state = {'test_set': test_dset}
+
+    # initialize manager
+    oscilloscope = manager.MeasurementManager(static_state, reporter)
+
+Once the `MeasurementManager` is initialized, you must then tell it which
+measurements to make, and at what interval to make them.  The measurement is
+specified by a dictionary with keys `name`, `interval`, and `function`.  Here
+`name` is a string specifying the measurement name; the `interval` is an
+integer that specifies the spacing, in steps, between subsequent measurements,
+and the `function` is a function which can perform a measurement given a state
+dictionary.  For example:
+
+.. code-block:: python
+
+    oscilloscope.add_measurement({'name': 'l2_norm',
+                                  'interval': 10,
+                                  'function': lambda state: l2norm(state['params']}))
+
+Then, during training, we can call the `process` function, but we need to pass
+the objects needed for measurements which vary during traning, e.g.
+
+.. code-block:: python
+
+    for step in training_steps:
+        optimizer_state = do_train_step()
+
+        current_dict = {'params': optimizer_state.params}
+        oscilloscope.process(step, current_dict)
+
+If we want to force a measurement when it wouldn't ordinarily be measured, we
+can use the `trigger_subset` method as follows
+
+.. code-block:: python
+
+    oscilloscope.trigger_subset(step, current_dict, ['test_acc']
+Indices and tables
+==================
+
+* :ref:`search`

--- a/tests/uv/manager/__init__.py
+++ b/tests/uv/manager/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/uv/manager/test_measurementmanager.py
+++ b/tests/uv/manager/test_measurementmanager.py
@@ -173,3 +173,32 @@ def test_state_usage():
           'value': step * step
       } for step in steps_measured]
   }
+
+
+def test_force_measure():
+  """ Tests that the measurement manager handles forced measurements, i.e.
+  measurements provided as a measurement_list argument, properly """
+
+  data_store = {}
+  reporter = r.MemoryReporter(data_store).stepped()
+
+  STATIC1 = 3.14
+  MEASURE_STEP = 4
+
+  static_state = {'STATIC1': STATIC1}
+  test_manager = m.MeasurementManager(static_state, reporter)
+
+  test_manager.add_measurement({
+      'name': "STATIC",
+      'interval': 3,
+      'function': lambda x: x['STATIC1']
+  })
+  test_manager.add_measurement({
+      'name': "NOTMEASURED",
+      'interval': 3,
+      'function': lambda x: 10.
+  })
+
+  test_manager.measure(MEASURE_STEP, {}, ['STATIC'])
+
+  assert data_store == {'STATIC': [{'step': MEASURE_STEP, 'value': STATIC1}]}

--- a/tests/uv/manager/test_measurementmanager.py
+++ b/tests/uv/manager/test_measurementmanager.py
@@ -1,0 +1,248 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests of manager functions."""
+
+import uv.reporter as r
+import uv.manager as m
+
+
+def test_manager_setup():
+  """Tests whether the MeasurementManager() object is setup
+  without error"""
+
+  reporter = r.MemoryReporter().stepped()
+  static_state = {}
+
+  test_manager = m.MeasurementManager(static_state, reporter)
+
+
+def test_add_measurement():
+  """Tests that measurements can be added to a MeasurementManager
+  object properly """
+
+  reporter = r.MemoryReporter().stepped()
+  static_state = {}
+
+  test_manager = m.MeasurementManager(static_state, reporter)
+
+  assert len(test_manager.measurements) == 0
+
+  test_manager.add_measurement({
+      'name': 'L2',
+      'interval': 10,
+      'function': lambda state: 0
+  })
+
+  assert len(test_manager.measurements) == 1
+  assert 'L2' in test_manager.measurements.keys()
+  assert test_manager.measurements['L2']['interval'] == 10
+  assert test_manager.measurements['L2']['function'](static_state) == 0
+
+
+def test_measurement_invervals():
+  """Tests that measurements occur at the specified intervals"""
+
+  data_store = {}
+  reporter = r.MemoryReporter(data_store).stepped()
+  static_state = {}
+
+  test_manager = m.MeasurementManager(static_state, reporter)
+
+  test_intervals = [10, 13, 17, 20]
+  for interval in test_intervals:
+    test_manager.add_measurement({
+        'name': f'Int_{interval}',
+        'interval': interval,
+        'function': lambda state: 0
+    })
+
+  TEST_STEPS = 100
+  for i in range(TEST_STEPS):
+    test_manager.process(i, {})
+
+  # check data_store
+  assert data_store == {
+      'Int_10': [{
+          'step': 0,
+          'value': 0
+      }, {
+          'step': 10,
+          'value': 0
+      }, {
+          'step': 20,
+          'value': 0
+      }, {
+          'step': 30,
+          'value': 0
+      }, {
+          'step': 40,
+          'value': 0
+      }, {
+          'step': 50,
+          'value': 0
+      }, {
+          'step': 60,
+          'value': 0
+      }, {
+          'step': 70,
+          'value': 0
+      }, {
+          'step': 80,
+          'value': 0
+      }, {
+          'step': 90,
+          'value': 0
+      }],
+      'Int_13': [{
+          'step': 0,
+          'value': 0
+      }, {
+          'step': 13,
+          'value': 0
+      }, {
+          'step': 26,
+          'value': 0
+      }, {
+          'step': 39,
+          'value': 0
+      }, {
+          'step': 52,
+          'value': 0
+      }, {
+          'step': 65,
+          'value': 0
+      }, {
+          'step': 78,
+          'value': 0
+      }, {
+          'step': 91,
+          'value': 0
+      }],
+      'Int_17': [{
+          'step': 0,
+          'value': 0
+      }, {
+          'step': 17,
+          'value': 0
+      }, {
+          'step': 34,
+          'value': 0
+      }, {
+          'step': 51,
+          'value': 0
+      }, {
+          'step': 68,
+          'value': 0
+      }, {
+          'step': 85,
+          'value': 0
+      }],
+      'Int_20': [{
+          'step': 0,
+          'value': 0
+      }, {
+          'step': 20,
+          'value': 0
+      }, {
+          'step': 40,
+          'value': 0
+      }, {
+          'step': 60,
+          'value': 0
+      }, {
+          'step': 80,
+          'value': 0
+      }]
+  }
+
+
+def test_state_usage():
+  """ Tests that the measurements are made on the proper state,
+  i.e. the static and dynamic states are used appropriately """
+  data_store = {}
+  reporter = r.MemoryReporter(data_store).stepped()
+  static_state = {'Value1': 2., 'Value2': 4.}
+
+  test_manager = m.MeasurementManager(static_state, reporter)
+
+  test_manager.add_measurement({
+      'name': 'Value1',
+      'interval': 3,
+      'function': lambda x: x['Value1']
+  })
+  test_manager.add_measurement({
+      'name': 'Value2',
+      'interval': 3,
+      'function': lambda x: x['Value2']
+  })
+  test_manager.add_measurement({
+      'name': 'sum_12',
+      'interval': 3,
+      'function': lambda x: x['Value2'] + x['Value1']
+  })
+  test_manager.add_measurement({
+      'name': 'sum_13',
+      'interval': 3,
+      'function': lambda x: x['Value1'] + x['Value3']
+  })
+  test_manager.add_measurement({
+      'name': 'Value3',
+      'interval': 3,
+      'function': lambda x: x['Value3']
+  })
+
+  TEST_STEPS = 5
+  for step in range(TEST_STEPS):
+    dynamic_state = {'Value3': step * step}
+    test_manager.process(step, dynamic_state)
+
+  assert data_store == {
+      'Value1': [{
+          'step': 0,
+          'value': 2.
+      }, {
+          'step': 3,
+          'value': 2.
+      }],
+      'Value2': [{
+          'step': 0,
+          'value': 4.
+      }, {
+          'step': 3,
+          'value': 4.
+      }],
+      'sum_12': [{
+          'step': 0,
+          'value': 6.
+      }, {
+          'step': 3,
+          'value': 6.
+      }],
+      'sum_13': [{
+          'step': 0,
+          'value': 2.
+      }, {
+          'step': 3,
+          'value': 11.
+      }],
+      'Value3': [{
+          'step': 0,
+          'value': 0
+      }, {
+          'step': 3,
+          'value': 9
+      }]
+  }

--- a/uv/manager/__init__.py
+++ b/uv/manager/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/uv/manager/__init__.py
+++ b/uv/manager/__init__.py
@@ -13,3 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Measurement manager interface and implementations."""
+
+from uv.manager.manager import MeasurementManager
+
+__all__ = ["MeasurementManager"]

--- a/uv/manager/__init__.py
+++ b/uv/manager/__init__.py
@@ -15,6 +15,6 @@
 # limitations under the License.
 """Measurement manager interface and implementations."""
 
-from uv.manager.manager import MeasurementManager
+from uv.manager.impl import MeasurementManager
 
 __all__ = ["MeasurementManager"]

--- a/uv/manager/manager.py
+++ b/uv/manager/manager.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The MeasurementManager class, which conducts and reports on measurements
+which may be measured at varying intervals through training."""
+
+from typing import Dict, Iterable, List, Any, Type, Union, Callable
+from uv.reporter import AbstractReporter
+
+
+class MeasurementManager:
+  """Class for a MeasurementManager.  This manager is instantiated with a
+  particular reporter, which it will use to report whatever measurements is
+  conducts.
+
+  The MeasurementManager has a set of measurements---stored in a dictionary
+  (described below)---which are to be carried out at a certain frequency, which
+  is specific to each measurement.
+
+  Whenever the MeasurementManager's process() function is called, with a
+  step number provided as an argument, the MeasurementManager decides which
+  measurements are required at each step, carries them out, and reports them.
+
+  In order to carry out the measurement, the Manager has a state (Dict) at each
+  step, which contains all the information necessary to perform the measurement.
+  Part of this state is static (e.g., the training dataset), while part can
+  change at each step.  This dynamic state is passed along in the process() call.
+
+  Args:
+    static_state: Dict of variables which will be used to compute the measured
+                  values.  The static_state is fixed throughout time.
+    reporter: Reporter which will report the measurements.
+  """
+
+  def __init__(self, static_state: Dict[str, Any],
+               reporter: Type[AbstractReporter]):
+    self.static_state = static_state
+    self.reporter = reporter
+    self.measurements = {}
+
+  def add_measurement(self, measurement_spec: Dict[str, Union[str, int,
+                                                              Callable]]):
+    """Adds a measurement specification to the MeasurementManager.
+    Args:
+      measurement_spec: Dict containing keys:
+        'name': String, the name of the measurement, e.g. 'training_loss'
+        'interval': Integer, how often to measure
+        'function': Function, taking in the state_dictionary, and returning the
+                              measured value
+    """
+    name = measurement_spec['name']
+    self.measurements[name] = {
+        'interval': measurement_spec['interval'],
+        'function': measurement_spec['function']
+    }
+
+  def process(self, step: int, dynamic_state: Dict[str, Any]):
+    """ At a given step, decide which measurements need to be
+    performed at this step and perform them
+
+    Args:
+      step: Integer, the number of the current step
+      dynamic_stat: Dict, the state variables necessary to perform the
+                    measurement
+    """
+
+    to_measure = []
+    for msmt_name, msmt_spec in self.measurements.items():
+      if step % msmt_spec['interval'] == 0:
+        to_measure.append(msmt_name)
+
+    if len(to_measure) > 0:
+      self.trigger_subset(step, dynamic_state, to_measure)
+
+  def trigger_subset(self, step: int, dynamic_state: Dict[str, Any],
+                     msmt_list: Iterable[str]):
+    """ Regardless of step, performs the measurements specified
+    by msmt_list and reports them """
+
+    full_state = {**self.static_state, **dynamic_state}
+
+    msmts = {}
+    for msmt_name in msmt_list:
+      msmt_fun = self.measurements[msmt_name]['function']
+      msmt_value = msmt_fun(full_state)
+
+      msmts[msmt_name] = msmt_value
+
+    self.reporter.report_all(step, msmts)

--- a/uv/manager/manager.py
+++ b/uv/manager/manager.py
@@ -77,8 +77,7 @@ class MeasurementManager:
 
     to_measure = self.required_measurements(step)
 
-    if len(to_measure) > 0:
-      self.perform_specified_measurements(step, dynamic_state, to_measure)
+    self.perform_specified_measurements(step, dynamic_state, to_measure)
 
   def required_measurements(self, step: int) -> Iterable[str]:
     """ Returns an iterable of measurement names which are to be
@@ -103,4 +102,5 @@ class MeasurementManager:
 
       measurements[name] = measured_value
 
-    self.reporter.report_all(step, measurements)
+    if len(measurements) > 0:
+      self.reporter.report_all(step, measurements)


### PR DESCRIPTION
This commit adds the `manager.py` file and corresponding documentation,
which allows for specifying a measurement schedule for automatic
measurement handling.