### PR TITLE
Fix makefile so it installs sphinx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ install:
 	rm -rf $(ENV_NAME)
 	virtualenv -p $(PYTHON_BIN) $(ENV_NAME)
 	$(PIP) install -r requirements-dev.txt && $(PIP) install -e .[tf]
+	$(PIP) install -r docs/requirements.txt
 
 .PHONY: test
 test: lint pytest


### PR DESCRIPTION
Adds a single line to the `Makefile` to install the requirements specified in the `docs/requirements.txt` file, which installs `sphinx-build` in the resulting VirtualEnv.  

Fixes issue #8  