### PR TITLE
add support for run name for mlflow

### DIFF
--- a/tests/uv/reporter/test_state.py
+++ b/tests/uv/reporter/test_state.py
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import mlflow as mlf
+import pprint as pp
+import uv
 import uv.reporter.state as s
 import uv.reporter.store as r
+import tempfile
 
 
 def test_global_reporter():
@@ -84,3 +88,92 @@ def test_global_reporter():
     s.report(4, "deeper", 12)
     assert reader2.read("deeper") == [12]
     assert reader3.read("deeper") == [10]
+
+
+def test_start_run(monkeypatch):
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+
+    mlf.set_tracking_uri(f'file:{tmpdir}/foo')
+
+    # no run should be active initially
+    assert mlf.active_run() is None
+
+    # test default args
+    with uv.start_run() as r:
+      active_run = mlf.active_run()
+      assert active_run is not None
+      assert active_run == r
+
+    # test explicit experiment name, run name, artifact location
+    cfg = {
+        'experiment_name': 'foo',
+        'run_name': 'bar',
+        'artifact_location': 'gs://foo/bar',
+    }
+
+    with uv.start_run(**cfg) as r:
+      active_run = mlf.active_run()
+      assert active_run is not None
+      assert active_run == r
+
+      assert r.data.tags['mlflow.runName'] == cfg['run_name']
+      assert mlf.get_experiment_by_name(cfg['experiment_name']) is not None
+      assert mlf.get_artifact_uri().startswith(cfg['artifact_location'])
+
+    # test env var experiment name, run name, artifact location
+    cfg = {
+        'MLFLOW_EXPERIMENT_NAME': 'env_foo',
+        'MLFLOW_RUN_NAME': 'env_bar',
+        'MLFLOW_ARTIFACT_ROOT': 'gs://env/foo/bar'
+    }
+
+    for k, v in cfg.items():
+      monkeypatch.setenv(k, v)
+
+    with uv.start_run() as r:
+      active_run = mlf.active_run()
+      assert active_run is not None
+      assert active_run == r
+
+      assert r.data.tags['mlflow.runName'] == cfg['MLFLOW_RUN_NAME']
+      assert mlf.get_experiment_by_name(
+          cfg['MLFLOW_EXPERIMENT_NAME']) is not None
+      assert mlf.get_artifact_uri().startswith(cfg['MLFLOW_ARTIFACT_ROOT'])
+
+    for k, v in cfg.items():
+      monkeypatch.delenv(k)
+
+    # test env var tags
+    cfg = {
+        'tag0': 'foo',
+        'tag1': 'bar',
+    }
+
+    for k, v in cfg.items():
+      monkeypatch.setenv(f'ENVVAR_{k}', v)
+
+    with uv.start_run() as r:
+      client = mlf.tracking.MlflowClient()
+      tags = client.get_run(r.info.run_id).data.tags
+      for k, v in cfg.items():
+        assert k in tags, pp.pformat(tags)
+        assert tags[k] == v, pp.pformat(tags)
+
+    for k in cfg:
+      monkeypatch.delenv(f'ENVVAR_{k}')
+
+    # test CAIP tags
+    monkeypatch.setenv('CLOUD_ML_JOB_ID', 'foo_cloud_job')
+
+    with uv.start_run() as r:
+      client = mlf.tracking.MlflowClient()
+      tags = client.get_run(r.info.run_id).data.tags
+      assert 'cloud_ml_job_details' in tags, pp.pformat(tags)
+      assert tags['cloud_ml_job_details'] == (
+          'https://console.cloud.google.com/ai-platform/jobs/foo_cloud_job')
+
+      assert 'cloud_ml_job_id' in tags, pp.pformat(tags)
+      assert tags['cloud_ml_job_id'] == 'foo_cloud_job'
+
+    monkeypatch.delenv('CLOUD_ML_JOB_ID')

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -90,11 +90,13 @@ def start_run(param_prefix: Optional[str] = None,
               experiment_name: Optional[str] = None,
               run_name: Optional[str] = None,
               artifact_location: Optional[str] = None,
-              **args):
+              **args) -> mlf.ActiveRun:
   """Close alias of mlflow.start_run. The only difference is that uv.start_run
   attempts to extract parameters from the environment and log those to the
   bound UV reporter using `report_params`.
 
+  Note that the returned value can be used as a context manager:
+  https://www.mlflow.org/docs/latest/python_api/mlflow.html#mlflow.start_run
   """
   if experiment_name is None:
     experiment_name = os.environ.get("MLFLOW_EXPERIMENT_NAME")

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -114,4 +114,14 @@ def start_run(param_prefix: Optional[str] = None,
   ret = mlf.start_run(run_name=run_name, **args)
   env_params = ue.extract_params(prefix=param_prefix)
   mlf.set_tags(env_params)
+
+  # for CAIP jobs, we add the job id as a tag, along with a link to the
+  # console page
+  cloud_ml_job_id = os.environ.get('CLOUD_ML_JOB_ID')
+  if cloud_ml_job_id is not None:
+    mlf.set_tag(
+        'cloud_ml_job_details',
+        f'https://console.cloud.google.com/ai-platform/jobs/{cloud_ml_job_id}')
+    mlf.set_tag('cloud_ml_job_id', cloud_ml_job_id)
+
   return ret

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -85,7 +85,10 @@ def report_params(m: Dict[str, str]) -> None:
   return get_reporter().report_params(m)
 
 
-def start_run(param_prefix: str = None, experiment_name: str = None, **args):
+def start_run(param_prefix: str = None,
+              experiment_name: str = None,
+              run_name: str = None,
+              **args):
   """Close alias of mlflow.start_run. The only difference is that uv.start_run
   attempts to extract parameters from the environment and log those to the
   bound UV reporter using `report_params`.
@@ -94,11 +97,14 @@ def start_run(param_prefix: str = None, experiment_name: str = None, **args):
   if experiment_name is None:
     experiment_name = os.environ.get("MLFLOW_EXPERIMENT_NAME")
 
+  if run_name is None:
+    run_name = os.environ.get("MLFLOW_RUN_NAME")
+
   # Make sure the experiment exists before the run starts.
   if experiment_name is not None:
     mlf.set_experiment(experiment_name)
 
-  ret = mlf.start_run(**args)
+  ret = mlf.start_run(run_name=run_name, **args)
   env_params = ue.extract_params(prefix=param_prefix)
   mlf.set_tags(env_params)
   return ret


### PR DESCRIPTION
This PR implements a change to set the MLFlow run name in the `uv.start_run` method. If the user does not set this explicitly, then this value is picked up from the environment variable `MLFLOW_RUN_NAME` in a manner similar to the way that the MLFLow experiment name is set in the same method.

This PR also adds support for setting the `artifact_root` for an mlflow experiment in the `uv.start_run` method.

Additionally, this adds tags for CAIP jobs to list the job id and a link to the ai-platform console page for the job