### PR TITLE
Fix flaky test in SQLReporter

### DIFF
--- a/tests/uv/sql/test_sql.py
+++ b/tests/uv/sql/test_sql.py
@@ -15,11 +15,11 @@
 # limitations under the License.
 """Tests for the SQL reader and reporter."""
 
-import time
 from contextlib import closing
 
 import uv.sql.reporter as sr
 import uv.sql.util as u
+from sqlalchemy.orm import sessionmaker
 
 import pytest
 
@@ -60,23 +60,30 @@ def test_rep_string():
 
 def test_of_sql_roundtrip(tmp_path):
   engine = u.sqlite_engine(str(tmp_path))
+  sm = u.session_maker(engine)
 
-  # you can't make a reporter with an engine pointing to a nonexistent DB:
+  # you can't make a reporter with an engine (or sessionmaker) pointing to a
+  # nonexistent DB:
   with pytest.raises(Exception):
     sr.SQLReporter(engine, sr.Experiment(id=10), 0)
+
+  with pytest.raises(Exception):
+    sr.SQLReporter(sm, sr.Experiment(id=10), 0)
 
   # Same goes for reader.
   with pytest.raises(Exception):
     sr.SQLReader(engine, sr.Experiment(id=10), 0)
 
+  with pytest.raises(Exception):
+    sr.SQLReader(sm, sr.Experiment(id=10), 0)
+
   sr.create_tables(engine)
-  experiment = sr.new_experiment(engine, {"learning_rate": 0.01})
 
-  with closing(sr.SQLReporter(engine, experiment, 0)) as reporter:
+  experiment = sr.new_experiment(sm, {"learning_rate": 0.01})
+
+  with closing(sr.SQLReporter(sm, experiment, 0)) as reporter:
     with closing(reporter.reader()) as reader:
-      with closing(sr.SQLReader(engine, experiment, 0)) as reader2:
-
-        time.sleep(1)
+      with closing(sr.SQLReader(sm, experiment, 0)) as reader2:
         reporter.report_all(0, {"a": 1})
         reporter.report_all(1, {"a": 2, "b": 3})
         reporter.report_all(2, {"b": 4})

--- a/uv/sql/reporter.py
+++ b/uv/sql/reporter.py
@@ -21,7 +21,7 @@ https://source.cloud.google.com/research-3141/tf2-jax-notebooks/+/master:experim
 """
 
 from itertools import groupby
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import uv.reader.base as rb
 import uv.sql.util as u
@@ -74,9 +74,10 @@ class Metric(Base):
     return u.rep_string(self)
 
 
-def new_experiment(engine, config: Dict[str, Any]) -> Experiment:
+def new_experiment(e: Union[Engine, sessionmaker],
+                   config: Dict[str, Any]) -> Experiment:
   """Generates a new experiment."""
-  session = sessionmaker(bind=engine)()
+  session = u.session_maker(e)()
   exp = Experiment(params=config)
   session.add(exp)
   session.commit()
@@ -90,16 +91,16 @@ creation, but that's coming.
 
   """
 
-  def __init__(self, engine: Engine, experiment: Experiment, run_id: int):
-    if not u.sqlite_file_exists(engine):
+  def __init__(self, e: Union[Engine, sessionmaker], experiment: Experiment,
+               run_id: int):
+    self._make_session = u.session_maker(e)
+    self._engine = self._make_session.kw["bind"]
+    if not u.sqlite_file_exists(self._engine):
       raise Exception(
-          f"{engine.url} doesn't exist! Create the database before creating a reporter."
+          f"{self._engine.url} doesn't exist! Create the database before creating a reporter."
       )
-
-    self._engine = engine
     self._experiment = experiment
     self._run_id = run_id
-    self._make_session = sessionmaker(bind=engine)
 
   def _metric(self, step: int, k: str, v: float) -> Metric:
     """Generates an instance of Metric tied to this specific reporter's
@@ -118,7 +119,7 @@ creation, but that's coming.
     session.commit()
 
   def reader(self) -> rb.AbstractReader:
-    return SQLReader(self._engine, self._experiment, self._run_id)
+    return SQLReader(self._make_session, self._experiment, self._run_id)
 
 
 class SQLReader(rb.AbstractReader, rb.IterableReader):
@@ -127,22 +128,22 @@ class SQLReader(rb.AbstractReader, rb.IterableReader):
   """
 
   def __init__(self,
-               engine: Engine,
+               e: Union[Engine, sessionmaker],
                experiment: Experiment,
                run_id: int,
                step_key: Optional[str] = None):
-    if not u.sqlite_file_exists(engine):
+    self._make_session = u.session_maker(e)
+    self._engine = self._make_session.kw["bind"]
+    if not u.sqlite_file_exists(self._engine):
       raise Exception(
-          f"{engine.url} doesn't exist! Create the database before creating a reader."
+          f"{self._engine.url} doesn't exist! Create the database before creating a reader."
       )
 
     if step_key is None:
       step_key = "step"
 
-    self._engine = engine
     self._experiment = experiment
     self._run_id = run_id
-    self._make_session = sessionmaker(bind=engine)
 
   def keys(self) -> Iterable[t.Metric]:
     """Returns a list of all keys in the DB for this particular experiment and

--- a/uv/sql/util.py
+++ b/uv/sql/util.py
@@ -18,11 +18,12 @@
 """
 
 import os
+from typing import Union
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import URL
-from typing import Union
+from sqlalchemy.orm import sessionmaker
 
 
 def sqlite_engine(location: str, verbose=False) -> Engine:
@@ -33,6 +34,17 @@ def sqlite_engine(location: str, verbose=False) -> Engine:
     location = f"{location}.db"
 
   return create_engine(f'sqlite:///{location}', echo=verbose)
+
+
+def session_maker(e: Union[Engine, sessionmaker]) -> sessionmaker:
+  """Returns a session maker from the specified Engine, or acts as identity if e
+  is already a sessionmaker.
+
+  """
+  if isinstance(e, sessionmaker):
+    return e
+
+  return sessionmaker(bind=e)
 
 
 def sqlite_file_exists(arg: Union[Engine, URL]) -> bool:


### PR DESCRIPTION
This fixes the flaky test by allowing objects to share the same session maker.