### PR TITLE
add sql module to api docs

### DIFF
--- a/docs/api/uv.sql.rst
+++ b/docs/api/uv.sql.rst
@@ -1,0 +1,30 @@
+uv.sql package
+==============
+
+Submodules
+----------
+
+uv.sql.reporter module
+----------------------
+
+.. automodule:: uv.sql.reporter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+uv.sql.util module
+------------------
+
+.. automodule:: uv.sql.util
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: uv.sql
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/uv/sql/__init__.py
+++ b/uv/sql/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
This is a simple change to add `uv.sql` to our api docs.