### PR TITLE
adds a project check for mlflow artifact storage when using gcs bucket

### DIFF
--- a/tests/uv/mlflow/test_reporter.py
+++ b/tests/uv/mlflow/test_reporter.py
@@ -36,7 +36,7 @@ def test_report_params():
     mlflow_cfg = {
         'experiment_name': 'foo',
         'run_name': 'bar',
-        'artifact_location': 'gs://foo/bar',
+        'artifact_location': '/foo/bar',
     }
 
     with uv.start_run(**mlflow_cfg) as active_run, uv.active_reporter(
@@ -67,7 +67,7 @@ def test_report_param():
     mlflow_cfg = {
         'experiment_name': 'foo',
         'run_name': 'bar',
-        'artifact_location': 'gs://foo/bar',
+        'artifact_location': '/foo/bar',
     }
 
     with uv.start_run(**mlflow_cfg) as active_run, uv.active_reporter(
@@ -98,7 +98,7 @@ def test_report_all():
     mlflow_cfg = {
         'experiment_name': 'foo',
         'run_name': 'bar',
-        'artifact_location': 'gs://foo/bar',
+        'artifact_location': '/foo/bar',
     }
 
     with uv.start_run(**mlflow_cfg) as active_run, uv.active_reporter(
@@ -154,7 +154,7 @@ def test_report():
     mlflow_cfg = {
         'experiment_name': 'foo',
         'run_name': 'bar',
-        'artifact_location': 'gs://foo/bar',
+        'artifact_location': '/foo/bar',
     }
 
     with uv.start_run(**mlflow_cfg) as active_run, uv.active_reporter(

--- a/tests/uv/reporter/test_state.py
+++ b/tests/uv/reporter/test_state.py
@@ -187,7 +187,7 @@ def test_start_run(monkeypatch):
 
     # explicitly test case where no default or explicit gcp project is set
     def mock_default():
-      return object(), None
+      return google.auth.credentials.AnonymousCredentials(), None
 
     orig_default = google.auth.default
     monkeypatch.setattr(google.auth, 'default', mock_default)

--- a/tests/uv/reporter/test_state.py
+++ b/tests/uv/reporter/test_state.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import google.auth
+import google
 import google.cloud.storage
 import mlflow as mlf
 import os

--- a/tests/uv/reporter/test_state.py
+++ b/tests/uv/reporter/test_state.py
@@ -186,10 +186,8 @@ def test_start_run(monkeypatch):
     monkeypatch.delenv('CLOUD_ML_JOB_ID')
 
     # explicitly test case where no default or explicit gcp project is set
-    creds, proj_id = google.auth.default()
-
     def mock_default():
-      return creds, None
+      return object(), None
 
     orig_default = google.auth.default
     monkeypatch.setattr(google.auth, 'default', mock_default)
@@ -209,12 +207,3 @@ def test_start_run(monkeypatch):
       assert mlf.get_experiment_by_name(cfg['experiment_name']) is not None
       assert mlf.get_artifact_uri().startswith(cfg['artifact_location'])
       assert os.environ.get('GOOGLE_CLOUD_PROJECT') is not None
-
-    # restore the true google.auth.default method and test that our fake
-    # project is set, and that it allows us to create a default
-    # storage client, as this is what mlflow will need
-    monkeypatch.setattr(google.auth, 'default', orig_default)
-    creds, proj = google.auth.default()
-    assert creds is not None
-    assert proj is not None
-    gcs_client = google.cloud.storage.Client()

--- a/tests/uv/reporter/test_state.py
+++ b/tests/uv/reporter/test_state.py
@@ -190,8 +190,7 @@ def test_start_run(monkeypatch):
     def mock_default(scopes=None, request=None, quota_project_id=None):
       return (google.auth.credentials.AnonymousCredentials(), None)
 
-    orig_default = google.auth.default
-    monkeypatch.setattr(google.auth, 'default', mock_default)
+    monkeypatch.setattr('google.auth.default', mock_default)
 
     cfg = {
         'experiment_name': 'foo',

--- a/tests/uv/reporter/test_state.py
+++ b/tests/uv/reporter/test_state.py
@@ -19,6 +19,7 @@ import google.cloud.storage
 import mlflow as mlf
 import os
 import pprint as pp
+import pytest
 import uv
 import uv.reporter.state as s
 import uv.reporter.store as r
@@ -186,8 +187,8 @@ def test_start_run(monkeypatch):
     monkeypatch.delenv('CLOUD_ML_JOB_ID')
 
     # explicitly test case where no default or explicit gcp project is set
-    def mock_default():
-      return google.auth.credentials.AnonymousCredentials(), None
+    def mock_default(scopes=None, request=None, quota_project_id=None):
+      return (google.auth.credentials.AnonymousCredentials(), None)
 
     orig_default = google.auth.default
     monkeypatch.setattr(google.auth, 'default', mock_default)

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -18,7 +18,7 @@
 import logging
 import os
 from contextlib import contextmanager
-import google
+import google.auth
 from typing import Dict, Optional
 
 import mlflow as mlf

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -17,7 +17,7 @@
 
 import os
 from contextlib import contextmanager
-import google.auth
+import google
 from typing import Dict, Optional
 
 import mlflow as mlf


### PR DESCRIPTION
This PR adds a check to make sure a gcs project is defined when storing artifacts to a gcs bucket from mlflow. This is necessary because mlflow creates a default `google.auth.storage.Client` instance for reading and writing to the bucket, which requires a non-null project to be returned from the `google.auth.default()` api call. 