### PR TITLE
edyer/mlflow report artifact

### DIFF
--- a/uv/__init__.py
+++ b/uv/__init__.py
@@ -16,7 +16,7 @@
 from uv.reporter.base import AbstractReporter
 from uv.reporter.state import (active_reporter, get_reporter, report,
                                report_all, report_param, report_params,
-                               set_reporter, start_run)
+                               report_artifact, set_reporter, start_run)
 from uv.reporter.store import LoggingReporter, MemoryReporter
 
 from ._version import get_versions
@@ -32,6 +32,7 @@ __all__ = [
     "report_all",
     "report_param",
     "report_params",
+    "report_artifact",
     "start_run",
     "AbstractReporter",
     "LoggingReporter",

--- a/uv/mlflow/reporter.py
+++ b/uv/mlflow/reporter.py
@@ -49,6 +49,14 @@ class MLFlowReporter(b.AbstractReporter):
                            params=params,
                            tags=tags)
 
+  def _log_artifact(self,
+                    local_path: str,
+                    run_id: Optional[str] = None) -> None:
+
+    run_id = run_id or mlf.active_run().info.run_id
+
+    self._client.log_artifact(run_id=run_id, local_path=local_path)
+
   def report_param(self, k: str, v: str) -> None:
     self.report_params({k: v})
 
@@ -62,6 +70,9 @@ class MLFlowReporter(b.AbstractReporter):
 
   def report(self, step: int, k: t.MetricKey, v: t.Metric) -> None:
     self.report_all(step=step, m={k: v})
+
+  def report_artifact(self, local_path: str) -> None:
+    self._log_artifact(local_path)
 
 
 def _metric_dict(

--- a/uv/reporter/state.py
+++ b/uv/reporter/state.py
@@ -88,6 +88,14 @@ def report_params(m: Dict[str, str]) -> None:
   return get_reporter().report_params(m)
 
 
+def report_artifact(local_path: str) -> None:
+  """Accepts a path to a local file and logs this file as an artifact. Reports
+  to the globally available reporter returned by uv.get_reporter().
+
+  """
+  return get_reporter().report_artifact(local_path)
+
+
 def _ensure_non_null_project(artifact_root: Optional[str]):
   '''Ensures that the google cloud python api methods can get a non-None
   project id when the mlflow artifact root is a storage bucket. This is necessary


### PR DESCRIPTION
Added a `report_artifact` method to the `MLFlowReporter`  and made available to uv state. `MLFlowReporter.report_artifact` takes a path to a previously saved file and syncs it as an artifact. In the future we may want this to take and auto-serialize an object instead. 