### PR TITLE
changes mlflow reporter to raise ValueError on unsupported metric type, removing numpy() conversion

### DIFF
--- a/tests/uv/util/test_init.py
+++ b/tests/uv/util/test_init.py
@@ -26,23 +26,6 @@ import pytest
 import uv.util as u
 
 
-class Wrapper():
-  """Wrapper class that has a numpy method, for testing."""
-
-  def __init__(self, x):
-    self._x = x
-
-  def numpy(self):
-    """Using this instead of importing tensorflow..."""
-    return np.float64(self._x)
-
-
-def test_to_metric():
-  x = Wrapper(100)
-  assert u.to_metric(100) == 100
-  assert u.to_metric(x) == np.float64(100)
-
-
 def test_to_serializable():
   """Check that various non-serializable things can in fact be serialized using
   this dispatch method."""

--- a/uv/util/__init__.py
+++ b/uv/util/__init__.py
@@ -24,15 +24,6 @@ import numpy as np
 import tqdm
 
 
-def to_metric(v: Any) -> float:
-  """Converts the incoming item into something we can log.
-  """
-  if hasattr(v, 'numpy'):
-    return v.numpy()
-
-  return v
-
-
 @singledispatch
 def to_serializable(val):
   """Used by default."""


### PR DESCRIPTION
This PR removes an internal `numpy()` metric type conversion to avoid a potential performance-degrading effect for values stored on an accelerator device. Instead, we now raise a `ValueError` explaining the failure.